### PR TITLE
fix: Gantt chart permissions fix

### DIFF
--- a/src/job_manager/services.py
+++ b/src/job_manager/services.py
@@ -567,7 +567,7 @@ class JobGanttChartService:
 
     def map_jobs_to_gantt(self) -> list:
         # check for permission to view job gantt chart
-        if not self.permission_service.check_for_permission("view_job_gantt_chart"):
+        if not self.user.is_authenticated:
             raise PermissionDenied()
 
         job_data = []


### PR DESCRIPTION
Fixed issue with Gantt Chart API data permission error

- We get PermissionDenied when retrieving Gantt chart data with a non-superuser admin
- Lowered the permission check to basic authentication until we work on the granular permissions task