### PR TITLE
fix/user-list-has-unexisting-urls

### DIFF
--- a/src/templates/users/list.html
+++ b/src/templates/users/list.html
@@ -33,8 +33,8 @@
                         <td class="w-4 p-4">
                             <div class="flex items-center">
                                 <input id="checkbox-table-search-1"
-                                    type="checkbox"
-                                    class="w-7 h-7 rounded-md bg-[#F1F1F2]">
+                                       type="checkbox"
+                                       class="w-7 h-7 rounded-md bg-[#F1F1F2]">
                             </div>
                         </td>
                         {% for cell in row %}
@@ -78,17 +78,22 @@
             <div class="flex items-center justify-between pt-7">
                 <div class="flex flex-1 justify-between sm:hidden">
                     {% if paginator.has_previous %}
-                    <a hx-get="{% url model_name %}" hx-target="#all-{{ model_name }}s-table" hx-trigger="keyup delayed:500ms"
-                        name="page_number" value="{{ paginator.previous_page_number }}"
-                        class="relative inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">Previous
-                    </a>
+                        <a hx-get="{% url 'users:list' %}"
+                           hx-target="#all-{{ model_name }}s-table"
+                           hx-trigger="keyup delayed:500ms"
+                           name="page_number"
+                           value="{{ paginator.previous_page_number }}"
+                           class="relative inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">Previous
+                        </a>
                     {% endif %}
-        
                     {% if paginator.has_next %}
-                    <a hx-get="{% url model_name %}" hx-target="#all-{{ model_name }}s-table" hx-trigger="keyup delayed:500ms"
-                        name="page_number" value="{{ paginator.next_page_number }}"
-                        class="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">Next
-                    </a>
+                        <a hx-get="{% url 'users:list' %}"
+                           hx-target="#all-{{ model_name }}s-table"
+                           hx-trigger="keyup delayed:500ms"
+                           name="page_number"
+                           value="{{ paginator.next_page_number }}"
+                           class="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">Next
+                        </a>
                     {% endif %}
                 </div>
                 <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
@@ -105,30 +110,35 @@
                     </div>
                     <div class="flex">
                         {% if paginator.has_previous %}
-                        <a href="{% url model_name %}?page={{ paginator.previous_page_number }}"
-                            hx-get="{% url model_name %}?page={{ paginator.previous_page_number }}"
-                            hx-target="#all-{{ model_name }}s-table" hx-trigger="click"
-                            class="relative inline-flex items-center rounded-full px-5 py-3 mr-3.5 border border-[#E1E3EA80] bg-white">
-                            <span class="sr-only">Previous</span>
-                            <img class="h-5 w-1.5" src="{% static 'images/left-arrow.svg' %}" alt="Previous" />
-                        </a>
+                            <a href="{% url 'users:list' %}?page={{ paginator.previous_page_number }}"
+                               hx-get="{% url 'users:list' %}?page={{ paginator.previous_page_number }}"
+                               hx-target="#all-{{ model_name }}s-table"
+                               hx-trigger="click"
+                               class="relative inline-flex items-center rounded-full px-5 py-3 mr-3.5 border border-[#E1E3EA80] bg-white">
+                                <span class="sr-only">Previous</span>
+                                <img class="h-5 w-1.5"
+                                     src="{% static 'images/left-arrow.svg' %}"
+                                     alt="Previous" />
+                            </a>
                         {% endif %}
-        
                         <span class="relative inline-flex items-center text-base font-semibold text-[#181C32]">Page</span>
                         <a aria-current="page"
-                            class="relative z-10 inline-flex items-center bg-white px-7 py-3 mx-2.5 text-sm font-semibold text-[#2884EF] border border-[#E1E3EA80] rounded-lg">
+                           class="relative z-10 inline-flex items-center bg-white px-7 py-3 mx-2.5 text-sm font-semibold text-[#2884EF] border border-[#E1E3EA80] rounded-lg">
                             {{ paginator.number }}
                         </a>
                         <span class="relative inline-flex items-center text-base font-semibold text-[#181C32]">Of</span>
                         <span class="relative z-10 inline-flex items-center bg-white px-7 py-3 mx-2.5 text-sm font-semibold text-[#2884EF] border border-[#E1E3EA80] rounded-lg">{{ num_pages }}</span>
                         {% if paginator.has_next %}
-                        <a href="{% url model_name %}?page={{ paginator.next_page_number }}"
-                            hx-get="{% url model_name %}?page={{ paginator.next_page_number }}"
-                            hx-target="#all-{{ model_name }}s-table" hx-trigger="click"
-                            class="relative inline-flex items-center rounded-full px-5 py-3 ml-3.5 border border-[#E1E3EA80] bg-white">
-                            <span class="sr-only">Next</span>
-                            <img class="h-5 w-1.5" src="{% static 'images/right-arrow.svg' %}" alt="Next" />
-                        </a>
+                            <a href="{% url 'users:list' %}?page={{ paginator.next_page_number }}"
+                               hx-get="{% url 'users:list' %}?page={{ paginator.next_page_number }}"
+                               hx-target="#all-{{ model_name }}s-table"
+                               hx-trigger="click"
+                               class="relative inline-flex items-center rounded-full px-5 py-3 ml-3.5 border border-[#E1E3EA80] bg-white">
+                                <span class="sr-only">Next</span>
+                                <img class="h-5 w-1.5"
+                                     src="{% static 'images/right-arrow.svg' %}"
+                                     alt="Next" />
+                            </a>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
![Screenshot from 2024-09-20 17-20-39](https://github.com/user-attachments/assets/2aad5b53-5193-4e78-aa85-ce43f5f6c55b)

We're calling a URL that isn't registered, so this fixes that by adding the `users` namespace. This view is only specific to the User app, so we can specify user-related URLs here.