### PR TITLE
fix: Added error handling for scheduler results and logs

### DIFF
--- a/src/scheduler/api/scheduler_run.py
+++ b/src/scheduler/api/scheduler_run.py
@@ -86,10 +86,21 @@ def start_scheduler_run(request):
             scheduler_status = SchedulerStatusChoices.COMPLETED
             scheduler_details = "Scheduler run completed successfully."
 
+        scheduler_results = {}
+        scheduler_logs = {}
+
+        if "error" in scheduled_task:
+            scheduler_results = scheduled_task["error"]
+            scheduler_logs = scheduled_task["error"]
+
+        else:
+            scheduler_results = scheduled_task["data"]
+            scheduler_logs = scheduled_task["logs"]
+
         save_scheduler_run(
-            scheduled_task.get("data", scheduled_task["error"]),
+            scheduler_results,
             scheduler_details,
-            scheduled_task.get("logs", {}),
+            scheduler_logs,
             scheduler_start_time,
             scheduler_end_time,
             scheduler_status,


### PR DESCRIPTION
Added handling for cases where the scheduler would just return an `'error'` key-value pair