### PR TITLE
fix: microbatch scheduling predecessor handling

### DIFF
--- a/src/microbatching/services/microbatch_flow.py
+++ b/src/microbatching/services/microbatch_flow.py
@@ -180,4 +180,10 @@ class MicrobatchFlowService:
             microbatched_tasks.append(task_group)
             predecessor_group = [task for task in task_group[task.id]]
 
+            # Set predecessors for next tasks with no subtasks
+            successor_tasks = task.successors.filter(sub_tasks__isnull=True)
+            if successor_tasks.exists():
+                for successor_task in successor_tasks:
+                    successor_task.predecessors.set(predecessor_group)
+
         return microbatched_tasks

--- a/src/templates/microbatching/microbatch_flow/list.html
+++ b/src/templates/microbatching/microbatch_flow/list.html
@@ -29,11 +29,6 @@
                     Generate Task Flows
                 </button>
 
-                <button class="text-base font-semibold text-white px-6 py-3 bg-[#023E8A] rounded-md"
-                    hx-post="{% url 'run_microbatch_scheduling' %}" type="button">
-                    Run Microbatch Scheduling
-                </button>
-
                 <a href="{% url model_name|add:'_form' %}"
                     class="text-base font-semibold text-white px-6 py-3 bg-[#023E8A] rounded-md">Create New {{ model_title | title }}</a>
             </div>


### PR DESCRIPTION
- Updated missing step in microbatch predecessor handling with non-microbatched successors
- Removed scheduling trigger in refactored microbatch list view