### PR TITLE
fix: we have to reload after login issue

### DIFF
--- a/src/templates/account/login.html
+++ b/src/templates/account/login.html
@@ -24,11 +24,8 @@
             <form
               id="login-form"
               class="space-y-4"
-              hx-post="{% url 'account_login' %}?next=/chart/"
-              hx-trigger="submit"
-              hx-headers='{"Cache-Control": "no-cache"}'
-              hx-push-url="true"
-              hx-target="body"
+              method="post"
+              action="{% url 'account_login' %}?next=/chart/"
               >
               {% csrf_token %}
 
@@ -116,7 +113,6 @@
 
               <!-- Sign In Button -->
               <button
-                href="{% url 'dashboard' gantt_type='job' home='true' %}"
                 type="submit"
                 class="w-full text-white bg-[#023E8A] focus:ring-4 focus:outline-none focus:ring-primary-300  rounded-lg font-semibold text-base px-5 py-2.5 text-center"
               >
@@ -127,9 +123,7 @@
               <p class="text-sm font-medium text-gray-500 text-center">
                 Already have an Account?
                 <a
-                  hx-get="{% url 'account_signup' %}"
-                  hx-target="body"
-                  hx-push-url="true"
+                  href="{% url 'account_signup' %}"
                   class="font-base text-[#023E8A] hover:underline"
                   >Sign up</a
                 >

--- a/src/templates/account/signup.html
+++ b/src/templates/account/signup.html
@@ -17,7 +17,7 @@
         <p class="text-sm font-medium text-gray-400">{{ form.non_field_errors | safe }}</p>
 
         <!-- Sign Up Form -->
-        <form class="space-y-4" hx-post="{% url 'account_signup' %}" hx-trigger="submit" hx-target="body" hx-push-url="true">
+        <form class="space-y-4" method="post" action="{% url 'account_signup' %}">
             {% csrf_token %}
             
             <!-- Email Input -->
@@ -77,15 +77,9 @@
             </div>
             <!-- Forgot Password Link -->
             <a
-              href="#"
-              hx-get="{% url 'account_reset_password' %}"
-              hx-trigger="click"
-              hx-swap="outerHTML"
-              hx-target="body"
-              hx-push-url="true"
-              class="text-sm font-medium text-[#023E8A] hover:underline"
-              >Forgot password?</a
-            >
+                href="{% url 'account_reset_password' %}"
+                class="text-sm font-medium text-[#023E8A] hover:underline"
+            >Forgot password?</a>
           </div>
             
             <!-- Optional: Redirect Field -->


### PR DESCRIPTION
#### Problem:  
HTMX was swapping the `<body>` after login, which caused `alphin.js` to not initialize correctly on the dashboard route.  

- The **dashboard route** uses the `src/templates/base/main.html` layout.  
- The **login route** uses the `src/templates/account/main.html` layout.  

These two layouts have different `<head>` tags, leading to different scripts being initialized. The script reinitialization issue occurs when switching between these routes via HTMX.  

#### Solution:  
Switch from HTMX-based login and signup handling to normal HTML form submission.  

By using regular form submission, we can handle the layout switch more cleanly, avoiding the script initialization problem.  
