### PR TITLE
fix: disable state of input fields and Assignment constraint form in view page

### DIFF
--- a/src/job_manager/forms/task.py
+++ b/src/job_manager/forms/task.py
@@ -154,7 +154,9 @@ class TaskForm(forms.ModelForm):
             ),
             "task_status": forms.Select(
                 attrs={
-                    "class": "pointer-events-none cursor-not-allowed border border-[#E1E3EA] text-gray-900 text-sm rounded-md focus:ring-blue-500 focus-visible:outline-none block w-full p-3 bg-inherit"
+                    "class": "border border-[#E1E3EA] text-gray-900 text-sm disabled:bg-gray-100 disabled:cursor-not-allowed rounded-md focus:ring-blue-500 focus-visible:outline-none block w-full p-3 bg-inherit",
+                    "disabled": "disabled",
+                    "readonly": "readonly",
                 }
             ),
             "work_center": forms.Select(

--- a/src/templates/components/details/form.html
+++ b/src/templates/components/details/form.html
@@ -50,7 +50,7 @@
         <hr>
         <div class="flex items-center justify-between">
             <h2 class="text-xl font-semibold text-[#5E6278] pb-8 mt-8">{{ inline_formset_title }}</h2>
-            {% if button_text != "Create" and button_text != "Edit"%}
+            {% if not view_mode and button_text != "Create" and button_text != "Edit"%}
                 <button id="delete-assignment-constriants" type="button"
                         x-data="{ clicked: false }"
                         :class="clicked ? 'bg-red-500 text-white' : 'bg-white text-red-500 border border-red-500'"
@@ -71,7 +71,13 @@
                         {% else %}
                             <div class="md:w-1/2 px-3 mb-6 mt-6">
                                 <div class="flex items-center">
-                                    <div class="w-1/8">{{ field|add_class:"border border-[#E1E3EA] text-gray-900 text-sm rounded-md focus:ring-blue-500 focus-visible:outline-none block w/1-2 p-3 bg-inherit" }}</div>
+                                    <div class="w-1/8">
+                                        {% if view_mode %}
+                                            {{ field|add_class:"border border-[#E1E3EA] text-gray-900 text-sm rounded-md focus:ring-blue-500 focus-visible:outline-none block w/1-2 p-3 bg-inherit"|attr:"disabled:true"|attr:"readonly:true" }}
+                                        {% else %}
+                                            {{ field|add_class:"border border-[#E1E3EA] text-gray-900 text-sm rounded-md focus:ring-blue-500 focus-visible:outline-none block w/1-2 p-3 bg-inherit" }}
+                                        {% endif %}
+                                    </div>
                                     <div class="w-1/2 p-3 pt-5">
                                         <label for="{{ field.id_for_label }}"
                                             class="block uppercase text-gray-700 text-xs font-bold mb-2">
@@ -93,7 +99,11 @@
                                     {% if field.field.required %}<span class="text-red-500">*</span>{% endif %}
                                 </label>
                             {% endif %}
-                            {{ field }}
+                            {% if view_mode %}
+                                {{ field|add_class:"border border-[#E1E3EA] text-gray-900 text-sm rounded-md focus:ring-blue-500 focus-visible:outline-none block w-full p-3 bg-gray-100"|attr:"disabled:true"|attr:"readonly:true" }}
+                            {% else %}
+                                {{ field }}
+                            {% endif %}
                             {% if field.help_text %}<p class="text-gray-600 text-xs italic">{{ field.help_text }}</p>{% endif %}
                             {% for error in field.errors %}<p class="text-red-500 text-xs italic">{{ error }}</p>{% endfor %}
                         </div>
@@ -128,29 +138,27 @@
 
     <hr class="pb-4 mt-8">
     <!-- Submit buttons -->
-    {% if not view_only %}
-        <div class="flex justify-left mt-6 space-x-4">
-            <button
-                class="text-[#181C32] bg-[#F1F1F2] focus:ring-4 font-semibold rounded-md text-base w-full sm:w-auto px-6 py-3 text-center">
-                <a href="{% url model_name %}" class="text-[#181C32]">Cancel</a>
-            </button>
-            {% if view_mode %}
-                {% if user|can:crud_action_rules.2 %}
-                    <button>
-                        <a href="{{ edit_url }}"
-                            class="text-white bg-[#023E8A] focus:ring-4 font-semibold rounded-md text-base w-full sm:w-auto px-6 py-3 text-center">
-                            {{ button_text }}
-                        </a>
-                    </button>
-                {% endif %}
-            {% else %}
-                {% if user|can:crud_action_rules.2 %}
-                    <button type="submit"
+    <div class="flex justify-left mt-6 space-x-4">
+        <button
+            class="text-[#181C32] bg-[#F1F1F2] focus:ring-4 font-semibold rounded-md text-base w-full sm:w-auto px-6 py-3 text-center">
+            <a href="{% url model_name %}" class="text-[#181C32]">Cancel</a>
+        </button>
+        {% if view_mode %}
+            {% if user|can:crud_action_rules.2 %}
+                <button>
+                    <a href="{{ edit_url }}"
                         class="text-white bg-[#023E8A] focus:ring-4 font-semibold rounded-md text-base w-full sm:w-auto px-6 py-3 text-center">
                         {{ button_text }}
-                    </button>
-                {% endif %}
+                    </a>
+                </button>
             {% endif %}
-        </div>
-    {% endif %}
+        {% else %}
+            {% if user|can:crud_action_rules.2 %}
+                <button type="submit"
+                    class="text-white bg-[#023E8A] focus:ring-4 font-semibold rounded-md text-base w-full sm:w-auto px-6 py-3 text-center">
+                    {{ button_text }}
+                </button>
+            {% endif %}
+        {% endif %}
+    </div>
 </form>


### PR DESCRIPTION
Fixes #266

This pull request resolves the issue described in #266.

Additionally, it also fix the `Assignment Constraint` form on the view page. The form is now displayed in a read-only state, making the input fields non-editable.

![image](https://github.com/user-attachments/assets/07b988c7-abad-4ae0-90ad-c66bd2c5de63)
