### PR TITLE
fix: client side memory usage (1.5 GB) for rendering large data in gantt chart

### DIFF
--- a/src/job_manager/views/gantt_chart.py
+++ b/src/job_manager/views/gantt_chart.py
@@ -9,8 +9,7 @@ from django.urls import reverse
 
 def dashboard_gantt_chart_view(request, gantt_type: str = "job", home: str = "true"):
     """
-    Dashboard
-        Job Task gantt chart data view
+    Dashboard Job Task gantt chart data view
 
     Args:
         request (HttpRequest): The HTTP request object.
@@ -22,32 +21,11 @@ def dashboard_gantt_chart_view(request, gantt_type: str = "job", home: str = "tr
     if request.user.require_password_change:
         return redirect(reverse("users:change_password"))
 
-    if "HX-Request" in request.headers and home == "false":
-        if gantt_type == "job":
-            return render(
-                request,
-                "dashboard/job_task_gantt.html",
-                {
-                    "gantt_chart_title": "Job Task",
-                    "API_BASE_URL": settings.API_BASE_URL,
-                },
-            )
-        else:
-            return render(
-                request,
-                "dashboard/resource_gantt.html",
-                {
-                    "gantt_chart_title": "Resource",
-                    "API_BASE_URL": settings.API_BASE_URL,
-                },
-            )
-
     return render(
         request,
         "dashboard/base.html",
         {
-            "gantt_chart_title": "Job Task",
-            "gantt_chart": "dashboard/job_task_gantt.html",
+            "gantt_chart_title": "Job Task" if gantt_type == "job" else "Resource",
             "API_BASE_URL": settings.API_BASE_URL,
         },
     )

--- a/src/templates/base/main.html
+++ b/src/templates/base/main.html
@@ -14,12 +14,12 @@
         factryflow
       {% endblock title %}
     </title>
-    <script src="https://cdn.jsdelivr.net/npm/jsgantt-improved@2.8.10/dist/jsgantt.min.js">
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsgantt-improved@2.8.10/dist/jsgantt.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/jsgantt-improved@2.8.10/dist/jsgantt.min.css" rel="stylesheet">
 
+
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jsgantt-improved@2.8.10/dist/jsgantt.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/htmx/1.9.8/htmx.min.js"
             integrity="sha512-wua2xfJY3quQbT5pSx40Tp5+LD/zpw/9hARj1zsjJOA+rCq7N7pf7wlBXXdn5iGjQI5HE7svGvPz529Q3gJDiA=="
             crossorigin="anonymous"

--- a/src/templates/dashboard/base.html
+++ b/src/templates/dashboard/base.html
@@ -39,9 +39,6 @@
 
             <!-- Job Task Gantt Chart Tab -->
             <button @click="selectedTab = 'jobGantt'" 
-                    hx-get="{% url 'dashboard' gantt_type='job' home='false' %}" 
-                    hx-swap="innerHTML" 
-                    hx-target="#gantt-chart"
                     :aria-selected="selectedTab === 'jobGantt'" 
                     :tabindex="selectedTab === 'jobGantt' ? '0' : '-1'"
                     :class="selectedTab === 'jobGantt' 
@@ -53,9 +50,6 @@
 
             <!-- Resource Gantt Chart Tab -->
             <button @click="selectedTab = 'resourceGantt'" 
-                    hx-get="{% url 'dashboard' gantt_type='resource' home='false' %}" 
-                    hx-swap="innerHTML" 
-                    hx-target="#gantt-chart"
                     :aria-selected="selectedTab === 'resourceGantt'" 
                     :tabindex="selectedTab === 'resourceGantt' ? '0' : '-1'"
                     :class="selectedTab === 'resourceGantt' 
@@ -64,20 +58,31 @@
                     class="h-min px-4 py-3 text-md" type="button" role="tab" aria-controls="tabpanelResourceGantt">
                 Resource Gantt Chart
             </button>
+
+            <!-- Refresh Button -->
+            <button @click="sessionStorage.removeItem('jobGanttData'); sessionStorage.removeItem('resourceGanttData'); 
+                          if (selectedTab === 'jobGantt') {
+                              refreshJobGantt();
+                          } else {
+                              refreshResourceGantt();
+                          }"
+                    class="ml-auto h-min px-4 py-3 text-md text-[#023E8A] hover:text-[#0056b3] flex items-center gap-2">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+                </svg>
+                Refresh Data
+            </button>
         </div>
-        <div class="px-4 py-6 text-slate-700 dark:text-violet-200 text-lg">
-            <div x-show="selectedTab === 'jobGantt'" id="tabpanelJobGantt" role="tabpanel" aria-label="Job Gantt Chart">
-                <h1 class="text-2xl font-semibold text-[#181C32]">Job-Task Gantt Chart</h1>
-            </div>
-            <div x-show="selectedTab === 'resourceGantt'" id="tabpanelResourceGantt" role="tabpanel" aria-label="Resource Gantt Chart">
-                <h1 class="text-2xl font-semibold text-[#181C32]">Resource Gantt Chart</h1>
-            </div>
-        </div>
-    </div>
     
-    <!-- Gantt Chart Section -->
-    <div id="gantt-chart">
-        {% include gantt_chart %}
+        <!-- Gantt Chart Section -->
+        <div id="gantt-chart">
+            <div x-show="selectedTab === 'jobGantt'" x-cloak id="jobGanttChart">
+                {% include 'dashboard/job_task_gantt.html' %}
+            </div>
+            <div x-show="selectedTab === 'resourceGantt'" x-cloak id="resourceGanttChart">
+                {% include 'dashboard/resource_gantt.html' %}
+            </div>
+        </div>
     </div>
 
     <script>
@@ -85,6 +90,28 @@
             const apiBaseUrl = "{{ API_BASE_URL }}";
             localStorage.setItem('API_BASE_URL', apiBaseUrl);
         });
+
+        function refreshJobGantt() {
+            const jobGanttDiv = document.getElementById('jobGanttChart');
+            if (jobGanttDiv) {
+                const loadingSpinner = jobGanttDiv.querySelector('#ganttLoading');
+                if (loadingSpinner) loadingSpinner.style.display = 'flex';
+                // Trigger a refresh of the job Gantt data
+                const jobGanttEvent = new Event('refreshJobGantt');
+                jobGanttDiv.dispatchEvent(jobGanttEvent);
+            }
+        }
+
+        function refreshResourceGantt() {
+            const resourceGanttDiv = document.getElementById('resourceGanttChart');
+            if (resourceGanttDiv) {
+                const loadingSpinner = resourceGanttDiv.querySelector('#ganttLoading');
+                if (loadingSpinner) loadingSpinner.style.display = 'flex';
+                // Trigger a refresh of the resource Gantt data
+                const resourceGanttEvent = new Event('refreshResourceGantt');
+                resourceGanttDiv.dispatchEvent(resourceGanttEvent);
+            }
+        }
     </script>
 
 {% endblock %}

--- a/src/templates/dashboard/job_task_gantt.html
+++ b/src/templates/dashboard/job_task_gantt.html
@@ -1,45 +1,200 @@
-<div style="position:relative; max-height: 75vh; overflow-y: auto;" class="gantt bg-white p-6 rounded-lg shadow-xl" id="GanttChartDIV"></div>
+<div class="gantt bg-white p-6 rounded-lg shadow-xl">
+    <h1 class="text-2xl pb-4 font-semibold text-[#181C32]">Job-Task Gantt Chart</h1>
+    <!-- Loading Spinner - Moved outside scrollable container -->
+    <div id="ganttLoadingForJob" class="relative inset-0 flex items-center justify-center bg-white bg-opacity-80 z-10">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-[#023E8A]"></div>
+    </div>
+    <div style="position:relative; max-height: calc(75vh - 4rem); overflow-y: auto;" id="GanttChartDIV">
+        <div id="GanttChartForJob" style="position: relative;">
+            <div id="ganttContent"></div>
+        </div>
+    </div>
+</div>
 
 <script>
+    // Global variables for virtualization
+    let allTasks = [];
+    let ganttInstance = null;
+    let isLoading = false;
+    const ROW_HEIGHT = 40; // Approximate height of each task row
+    const BUFFER_SIZE = 40; // Number of items to render above and below viewport
+    const VIEWPORT_ITEMS = 40; // Approximate number of items visible in viewport
+    let currentStartIndex = 0;
+    let lastScrollTop = 0;
+
+    // Hide loading initially since the div starts empty
+    document.getElementById('ganttLoadingForJob').style.display = 'none';
     
-    var g = new JSGantt.GanttChart(document.getElementById('GanttChartDIV'), 'day');
+    function initializeJobGantt() {
+        var g = new JSGantt.GanttChart(document.getElementById('ganttContent'), 'day');
+        ganttInstance = g;
 
-    g.setOptions({
-        vCaptionType: 'Complete',  // Set to Show Caption : None,Caption,Resource,Duration,Complete,     
-        vQuarterColWidth: 36,
-        vDateTaskDisplayFormat: 'day dd month yyyy', // Shown in tool tip box
-        vDayMajorDateDisplayFormat: 'mon yyyy - Week ww',// Set format to dates in the "Major" header of the "Day" view
-        vWeekMinorDateDisplayFormat: 'dd mon', // Set format to display dates in the "Minor" header of the "Week" view
-        vLang: 'en',
-        vShowTaskInfoLink: 1, // Show link in tool tip (0/1)
-        vShowEndWeekDate: 0,  // Show/Hide the date for the last day of the week in header for daily
-        vShowEndDate: 0,
-        vShowStartDate: 0,
-        vShowComp: 0,
-        vShowTaskInfoComp: 0,
+        g.setOptions({
+            vCaptionType: 'Complete',
+            vQuarterColWidth: 36,
+            vDateTaskDisplayFormat: 'day dd month yyyy',
+            vDayMajorDateDisplayFormat: 'mon yyyy - Week ww',
+            vWeekMinorDateDisplayFormat: 'dd mon',
+            vLang: 'en',
+            vShowTaskInfoLink: 1,
+            vShowEndWeekDate: 0,
+            vShowEndDate: 0,
+            vShowStartDate: 0,
+            vShowComp: 0,
+            vShowTaskInfoComp: 0,
+            vAdditionalHeaders: {
+                priority: {
+                    title: 'Priority'
+                }
+            },
+            vUseSingleCell: 1000,
+            vScrollTo: 'today',
+            vMinGpLen: 20,
+        });
+
+        return g;
+    }
+
+    function getVisibleRange(scrollTop) {
+        // Calculate the start index based on scroll position
+        const estimatedStartIndex = Math.floor(scrollTop / ROW_HEIGHT);
+        const startIndex = Math.max(0, estimatedStartIndex - BUFFER_SIZE);
+        const endIndex = Math.min(
+            allTasks.length,
+            estimatedStartIndex + VIEWPORT_ITEMS + (2 * BUFFER_SIZE)
+        );
         
-        vAdditionalHeaders: { // Add data columns to your table
-            priority: {
-                title: 'Priority'
-            }
-        },
-        vUseSingleCell: 10000, // Set the threshold cell per table row (Helps performance for large data.
-        vFormatArr: ['Day', 'Week', 'Month', 'Quarter'], // Even with setUseSingleCell using Hour format on such a large chart can cause issues in some browsers,
+        return { startIndex, endIndex };
+    }
 
-        vMinGpLen: 20,
+    function drawJobGanttChart(tasks) {
+        if (isLoading) return;
+        isLoading = true;
+
+        try {
+            // Clear and reinitialize
+            document.getElementById('ganttContent').innerHTML = '';
+            ganttInstance = initializeJobGantt();
+
+            // Set container height for proper scrolling
+            const totalHeight = allTasks.length * ROW_HEIGHT;
+            document.getElementById('GanttChartForJob').style.height = `${totalHeight}px`;
+            document.getElementById('ganttContent').style.position = 'absolute';
+            document.getElementById('ganttContent').style.width = '100%';
+            document.getElementById('ganttContent').style.top = `${currentStartIndex * ROW_HEIGHT}px`;
+
+            // Add visible tasks
+            tasks.forEach(task => {
+                ganttInstance.AddTaskItemObject(task);
+            });
+
+            ganttInstance.Draw();
+        } finally {
+            isLoading = false;
+        }
+    }
+
+    function handleGanttScroll(event) {
+        if (isLoading) return;
+
+        const container = event.target;
+        const scrollTop = container.scrollTop;
+        const scrollDiff = Math.abs(scrollTop - lastScrollTop);
+        
+        // Only process if we've scrolled at least half a row height
+        if (scrollDiff < ROW_HEIGHT / 2) return;
+
+        // Get the range of items that should be visible
+        const { startIndex, endIndex } = getVisibleRange(scrollTop);
+        
+        // Only redraw if the visible range has changed significantly
+        if (Math.abs(startIndex - currentStartIndex) >= Math.floor(BUFFER_SIZE / 2)) {
+            currentStartIndex = startIndex;
+            const visibleTasks = allTasks.slice(startIndex, endIndex);
+            drawJobGanttChart(visibleTasks);
+        }
+
+        lastScrollTop = scrollTop;
+    }
+
+    function loadJobGanttData() {
+        document.getElementById('ganttLoadingForJob').style.display = 'flex';
+        isLoading = true;
+        currentStartIndex = 0;
+        lastScrollTop = 0;
+
+        // Check if we have cached data in sessionStorage
+        const cachedData = sessionStorage.getItem('jobGanttData');
+        if (cachedData) {
+            allTasks = JSON.parse(cachedData);
+            const { startIndex, endIndex } = getVisibleRange(0);
+            const initialTasks = allTasks.slice(startIndex, endIndex);
+            drawJobGanttChart(initialTasks);
+            ensureProperInitialization();
+            isLoading = false;
+            document.getElementById('ganttLoadingForJob').style.display = 'none';
+            return;
+        }
+
+        // If no cached data, fetch from API
+        axios.get(`${localStorage.getItem('API_BASE_URL')}api/job/gantt`)
+            .then(response => {
+                allTasks = response.data;
+                // Cache the data in sessionStorage
+                sessionStorage.setItem('jobGanttData', JSON.stringify(allTasks));
+                const { startIndex, endIndex } = getVisibleRange(0);
+                const initialTasks = allTasks.slice(startIndex, endIndex);
+                drawJobGanttChart(initialTasks);
+                ensureProperInitialization();
+            })
+            .catch(error => {
+                console.error(error);
+            })
+            .finally(() => {
+                isLoading = false;
+                document.getElementById('ganttLoadingForJob').style.display = 'none';
+            });
+    }
+
+    // Function to ensure proper initialization of Gantt chart dimensions
+    function ensureProperInitialization() {
+        // Force a reflow of the container
+        const container = document.getElementById('GanttChartDIV');
+        const content = document.getElementById('ganttContent');
+        
+        // Set initial dimensions
+        if (allTasks.length > 0) {
+            const totalHeight = allTasks.length * ROW_HEIGHT;
+            document.getElementById('GanttChartForJob').style.height = `${totalHeight}px`;
+            content.style.position = 'relative';
+            content.style.width = '100%';
+            content.style.top = `${currentStartIndex * ROW_HEIGHT}px`;
+            
+            // Force a redraw by triggering a resize event
+            window.dispatchEvent(new Event('resize'));
+        }
+    }
+
+    // Initial load
+    loadJobGanttData();
+
+    // Add scroll event listener with throttle for smoother performance
+    document.getElementById('GanttChartDIV').addEventListener('scroll', _.throttle(handleGanttScroll, 100));
+
+    // Listen for refresh events
+    document.getElementById('jobGanttChart').addEventListener('refreshJobGantt', () => {
+        // Clear session storage to force fresh data load
+        sessionStorage.removeItem('jobGanttData');
+        loadJobGanttData();
     });
 
-
-    // to get data from the api and display it in the gantt chart    
-    axios.get(`${localStorage.getItem('API_BASE_URL')}/api/job/gantt`)
-        .then(response => {
-        let tasks = response.data;
-        tasks.forEach(task => {
-            g.AddTaskItemObject(task);
-        });
-        g.Draw();
-        })
-        .catch(error => {
-        console.error(error);
-        });
+    // Handle window resize
+    window.addEventListener('resize', _.debounce(() => {
+        if (!isLoading && allTasks.length > 0) {
+            const container = document.getElementById('GanttChartDIV');
+            const { startIndex, endIndex } = getVisibleRange(container.scrollTop);
+            const visibleTasks = allTasks.slice(startIndex, endIndex);
+            drawJobGanttChart(visibleTasks);
+        }
+    }, 100));
 </script>

--- a/src/templates/dashboard/resource_gantt.html
+++ b/src/templates/dashboard/resource_gantt.html
@@ -1,39 +1,195 @@
-<div style="position:relative; max-height: 75vh; overflow-y: auto;" class="gantt bg-white p-6 rounded-lg shadow-xl" id="GanttChartDIV"></div>
+<div class="gantt bg-white p-6 rounded-lg shadow-xl">
+    <h1 class="text-2xl pb-4 font-semibold text-[#181C32]">Resource Gantt Chart</h1>
+    <!-- Loading Spinner - Moved outside scrollable container -->
+    <div id="ganttLoadingForResource" class="relative inset-0 flex items-center justify-center bg-white bg-opacity-80 z-10">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-[#023E8A]"></div>
+    </div>
+    <div style="position:relative; max-height: calc(75vh - 4rem); overflow-y: auto;" id="ResourceGanttChartDIV">
+        <div id="GanttChartForResource" style="position: relative;">
+            <div id="resourceGanttContent"></div>
+        </div>
+    </div>
+</div>
 
 <script>
+    // Global variables for virtualization
+    let allResourceTasks = [];
+    let resourceGanttInstance = null;
+    let isResourceLoading = false;
+    const RESOURCE_ROW_HEIGHT = 40; // Approximate height of each task row
+    const RESOURCE_BUFFER_SIZE = 40; // Number of items to render above and below viewport
+    const RESOURCE_VIEWPORT_ITEMS = 40; // Approximate number of items visible in viewport
+    let currentResourceStartIndex = 0;
+    let lastResourceScrollTop = 0;
 
-    var g = new JSGantt.GanttChart(document.getElementById('GanttChartDIV'), 'day');
+    // Hide loading initially since the div starts empty
+    document.getElementById('ganttLoadingForResource').style.display = 'none';
 
-    g.setOptions({
-        vCaptionType: 'Complete',  // Set to Show Caption : None,Caption,Resource,Duration,Complete,     
-        vQuarterColWidth: 36,
-        vDateTaskDisplayFormat: 'day dd month yyyy', // Shown in tool tip box
-        vDayMajorDateDisplayFormat: 'mon yyyy - Week ww',// Set format to dates in the "Major" header of the "Day" view
-        vWeekMinorDateDisplayFormat: 'dd mon', // Set format to display dates in the "Minor" header of the "Week" view
-        vLang: 'en',
-        vShowTaskInfoLink: 1, // Show link in tool tip (0/1)
-        vShowEndWeekDate: 0,  // Show/Hide the date for the last day of the week in header for daily
-        vShowEndDate: 0,
-        vShowStartDate: 0,
-        vShowComp: 0,
-        vShowTaskInfoComp: 0,
-        vUseSingleCell: 10000, // Set the threshold cell per table row (Helps performance for large data.
-        vFormatArr: ['Day', 'Week', 'Month', 'Quarter'], // Even with setUseSingleCell using Hour format on such a large chart can cause issues in some browsers,
+    function initializeResourceGantt() {
+        var g = new JSGantt.GanttChart(document.getElementById('resourceGanttContent'), 'day');
+        resourceGanttInstance = g;
 
-        vMinGpLen: 20,
+        g.setOptions({
+            vCaptionType: 'Complete',
+            vQuarterColWidth: 36,
+            vDateTaskDisplayFormat: 'day dd month yyyy',
+            vDayMajorDateDisplayFormat: 'mon yyyy - Week ww',
+            vWeekMinorDateDisplayFormat: 'dd mon',
+            vLang: 'en',
+            vShowTaskInfoLink: 1,
+            vShowEndWeekDate: 0,
+            vShowEndDate: 0,
+            vShowStartDate: 0,
+            vShowComp: 0,
+            vShowTaskInfoComp: 0,
+            vUseSingleCell: 10000,
+            vFormatArr: ['Day', 'Week', 'Month', 'Quarter'],
+            vMinGpLen: 20,
+        });
+
+        return g;
+    }
+
+    function getVisibleResourceRange(scrollTop) {
+        // Calculate the start index based on scroll position
+        const estimatedStartIndex = Math.floor(scrollTop / RESOURCE_ROW_HEIGHT);
+        const startIndex = Math.max(0, estimatedStartIndex - RESOURCE_BUFFER_SIZE);
+        const endIndex = Math.min(
+            allResourceTasks.length,
+            estimatedStartIndex + RESOURCE_VIEWPORT_ITEMS + (2 * RESOURCE_BUFFER_SIZE)
+        );
+        
+        return { startIndex, endIndex };
+    }
+
+    function drawResourceGanttChart(tasks) {
+        if (isResourceLoading) return;
+        isResourceLoading = true;
+
+        try {
+            // Clear and reinitialize
+            document.getElementById('resourceGanttContent').innerHTML = '';
+            resourceGanttInstance = initializeResourceGantt();
+
+            // Set container height for proper scrolling
+            const totalHeight = allResourceTasks.length * RESOURCE_ROW_HEIGHT;
+            document.getElementById('GanttChartForResource').style.height = `${totalHeight}px`;
+            document.getElementById('resourceGanttContent').style.position = 'absolute';
+            document.getElementById('resourceGanttContent').style.width = '100%';
+            document.getElementById('resourceGanttContent').style.top = `${currentResourceStartIndex * RESOURCE_ROW_HEIGHT}px`;
+
+            // Add visible tasks
+            tasks.forEach(task => {
+                resourceGanttInstance.AddTaskItemObject(task);
+            });
+
+            resourceGanttInstance.Draw();
+        } finally {
+            isResourceLoading = false;
+        }
+    }
+
+    function handleResourceGanttScroll(event) {
+        if (isResourceLoading) return;
+
+        const container = event.target;
+        const scrollTop = container.scrollTop;
+        const scrollDiff = Math.abs(scrollTop - lastResourceScrollTop);
+        
+        // Only process if we've scrolled at least half a row height
+        if (scrollDiff < RESOURCE_ROW_HEIGHT / 2) return;
+
+        // Get the range of items that should be visible
+        const { startIndex, endIndex } = getVisibleResourceRange(scrollTop);
+        
+        // Only redraw if the visible range has changed significantly
+        if (Math.abs(startIndex - currentResourceStartIndex) >= Math.floor(RESOURCE_BUFFER_SIZE / 2)) {
+            currentResourceStartIndex = startIndex;
+            const visibleTasks = allResourceTasks.slice(startIndex, endIndex);
+            drawResourceGanttChart(visibleTasks);
+        }
+
+        lastResourceScrollTop = scrollTop;
+    }
+
+    function loadResourceGanttData() {
+        document.getElementById('ganttLoadingForResource').style.display = 'flex';
+        isResourceLoading = true;
+        currentResourceStartIndex = 0;
+        lastResourceScrollTop = 0;
+
+        // Check if we have cached data in sessionStorage
+        const cachedData = sessionStorage.getItem('resourceGanttData');
+        if (cachedData) {
+            allResourceTasks = JSON.parse(cachedData);
+            const { startIndex, endIndex } = getVisibleResourceRange(0);
+            const initialTasks = allResourceTasks.slice(startIndex, endIndex);
+            drawResourceGanttChart(initialTasks);
+            ensureProperResourceInitialization();
+            isResourceLoading = false;
+            document.getElementById('ganttLoadingForResource').style.display = 'none';
+            return;
+        }
+
+        // If no cached data, fetch from API
+        axios.get(`${localStorage.getItem('API_BASE_URL')}api/resource/gantt`)
+            .then(response => {
+                allResourceTasks = response.data;
+                // Cache the data in sessionStorage
+                sessionStorage.setItem('resourceGanttData', JSON.stringify(allResourceTasks));
+                const { startIndex, endIndex } = getVisibleResourceRange(0);
+                const initialTasks = allResourceTasks.slice(startIndex, endIndex);
+                drawResourceGanttChart(initialTasks);
+                ensureProperResourceInitialization();
+            })
+            .catch(error => {
+                console.error(error);
+            })
+            .finally(() => {
+                isResourceLoading = false;
+                document.getElementById('ganttLoadingForResource').style.display = 'none';
+            });
+    }
+
+    // Function to ensure proper initialization of Resource Gantt chart dimensions
+    function ensureProperResourceInitialization() {
+        // Force a reflow of the container
+        const container = document.getElementById('ResourceGanttChartDIV');
+        const content = document.getElementById('resourceGanttContent');
+        
+        // Set initial dimensions
+        if (allResourceTasks.length > 0) {
+            const totalHeight = allResourceTasks.length * RESOURCE_ROW_HEIGHT;
+            document.getElementById('GanttChartForResource').style.height = `${totalHeight}px`;
+            content.style.position = 'relative';
+            content.style.width = '100%';
+            content.style.top = `${currentResourceStartIndex * RESOURCE_ROW_HEIGHT}px`;
+            
+            // Force a redraw by triggering a resize event
+            window.dispatchEvent(new Event('resize'));
+        }
+    }
+
+    // Initial load
+    loadResourceGanttData();
+
+    // Add scroll event listener with throttle for smoother performance
+    document.getElementById('ResourceGanttChartDIV').addEventListener('scroll', _.throttle(handleResourceGanttScroll, 100));
+
+    // Listen for refresh events
+    document.getElementById('resourceGanttChart').addEventListener('refreshResourceGantt', () => {
+        // Clear session storage to force fresh data load
+        sessionStorage.removeItem('resourceGanttData');
+        loadResourceGanttData();
     });
 
-
-    // to get data from the api and display it in the gantt chart
-    axios.get(`${localStorage.getItem('API_BASE_URL')}/api/resource/gantt`)
-        .then(response => {
-        let tasks = response.data;
-        tasks.forEach(task => {
-            g.AddTaskItemObject(task);
-        });
-        g.Draw();
-        })
-        .catch(error => {
-        console.error(error);
-        });
+    // Handle window resize
+    window.addEventListener('resize', _.debounce(() => {
+        if (!isResourceLoading && allResourceTasks.length > 0) {
+            const container = document.getElementById('ResourceGanttChartDIV');
+            const { startIndex, endIndex } = getVisibleResourceRange(container.scrollTop);
+            const visibleTasks = allResourceTasks.slice(startIndex, endIndex);
+            drawResourceGanttChart(visibleTasks);
+        }
+    }, 100));
 </script>


### PR DESCRIPTION
Using [virtualisation technique](https://x.com/aidenybai/status/1879585589999116522) this issue #270 is solved through client side optimization.

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/6e6bdfc7-9d59-41c3-8b85-3904803f22e7) | ![image](https://github.com/user-attachments/assets/576a2d7c-a3a6-4bd0-a81a-6a17b03802bf)  |

**Before these changes:**
- Rendering 5,000 elements in the DOM (Gantt chart) consumed 1.5 GB of RAM.
- There was no loading state, which impacted the user experience.

**After these changes:**
- Memory usage has been reduced to a maximum of 300 MB for rendering large data.
- A loading state has been added to improve UX.
- Client-side tab toggle functionality has replaced HTMX for toggling Gantt chart visibility.