### PR TITLE
added the pagiation to api end points to fetch gannt chart data in ba…

### DIFF
--- a/src/job_manager/api/chart_data.py
+++ b/src/job_manager/api/chart_data.py
@@ -8,18 +8,24 @@ class JobGanttAPIView(View):
         """Use JobGanttChartService to map jobs to
         gantt chart data and return as JSON.
         """
+        page = int(request.GET.get('page', 1))
+        page_size = int(request.GET.get('page_size', 50))
+        
         service = JobGanttChartService(user=request.user)
-        gantt_data = service.map_jobs_to_gantt()
+        gantt_data = service.map_jobs_to_gantt(page=page, page_size=page_size)
 
         return JsonResponse(gantt_data, status=200, safe=False)
 
 
 class ResourceGanttAPIView(View):
     def get(self, request):
-        """Use JobGanttChartService to map jobs to
+        """Use ResourceGanttChartService to map resources to
         gantt chart data and return as JSON.
         """
+        page = int(request.GET.get('page', 1))
+        page_size = int(request.GET.get('page_size', 50))
+        
         service = ResourceGanttChartService(user=request.user)
-        gantt_data = service.map_resources_to_gantt()
+        gantt_data = service.map_resources_to_gantt(page=page, page_size=page_size)
 
         return JsonResponse(gantt_data, status=200, safe=False)

--- a/src/job_manager/services/gantt_chart.py
+++ b/src/job_manager/services/gantt_chart.py
@@ -1,5 +1,6 @@
 from api.permission_checker import AbstractPermissionService
 from django.core.exceptions import PermissionDenied
+from django.core.paginator import Paginator
 from resource_assigner.models import TaskResourceAssigment
 from resource_manager.models import Resource
 
@@ -15,119 +16,57 @@ class JobGanttChartService:
         self.user = user
         self.permission_service = AbstractPermissionService(user=user)
 
-    def map_jobs_to_gantt(self) -> list:
-        # check for permission to view job gantt chart
-        if not self.user.is_authenticated:
-            raise PermissionDenied()
-
-        job_data = []
-        jobs = Job.objects.prefetch_related("tasks").order_by("priority")
-
-        gantt_pid = 1
+    def get_flattened_job_data(self, jobs):
+        """Helper method to flatten jobs and tasks into a single list for pagination"""
+        flattened_data = []
+        pid = 1
 
         for job in jobs:
             if job.tasks.count() > 0:
-                job_pid = gantt_pid
-                job_data.append(
-                    {
-                        "pID": job_pid,
-                        "pName": job.name,
-                        "pStart": "",
-                        "pEnd": "",
-                        "pClass": "gtaskblue",
-                        "pLink": "",
-                        "pMile": 0,
-                        "pRes": "",
-                        "pComp": 0,
-                        "pGroup": 1,
-                        "pParent": 0,
-                        "pOpen": 1,
-                        "pDepend": "",
-                        "pCaption": "",
-                        "pNotes": "",
-                        "pPlanStart": job.planned_start_datetime,
-                        "pPlanEnd": job.planned_end_datetime,
-                    }
-                )
+                # Add job
+                job_pid = pid
+                flattened_data.append({
+                    "type": "job",
+                    "pid": job_pid,
+                    "job": job,
+                })
+                pid += 1
 
-                gantt_pid += 1
-
+                # Add tasks
                 for task in job.tasks.all():
-                    if hasattr(task, "taskresourceassigment"):
-                        assignment = task.taskresourceassigment
-                        if assignment.resources:
-                            resource_name = ", ".join(
-                                [
-                                    resource.name
-                                    for resource in assignment.resources.all()
-                                ]
-                            )
-                    else:
-                        resource_name = ""
+                    flattened_data.append({
+                        "type": "task",
+                        "pid": pid,
+                        "task": task,
+                        "parent_pid": job_pid,
+                        "job": job,
+                    })
+                    pid += 1
 
-                    job_data.append(
-                        {
-                            "pID": gantt_pid,
-                            "pName": task.name,
-                            "pStart": "",
-                            "pEnd": "",
-                            "pClass": "gtaskblue",
-                            "pLink": "",
-                            "pMile": 0,
-                            "pRes": resource_name,
-                            "pComp": 0,
-                            "pGroup": 0,
-                            "pParent": job_pid,
-                            "pOpen": 1,
-                            "pDepend": list(
-                                task.predecessors.values_list("id", flat=True)
-                            ),
-                            "pNotes": task.notes,
-                            "priority": job.priority,
-                            "pCaption": "",
-                            "pPlanStart": task.planned_start_datetime,
-                            "pPlanEnd": task.planned_end_datetime,
-                        }
-                    )
+        return flattened_data
 
-                    gantt_pid += 1
-
-        return job_data
-
-
-# ------------------------------------------------------------------------------
-# Resource Gantt Chart Service
-# ------------------------------------------------------------------------------
-
-
-class ResourceGanttChartService:
-    def __init__(self, user) -> None:
-        self.user = user
-        self.permission_service = AbstractPermissionService(user=user)
-
-    def map_resources_to_gantt(self) -> list:
-        # check for permission to view job gantt chart
+    def map_jobs_to_gantt(self, page=1, page_size=50) -> dict:
+        """Map jobs to gantt chart data with proper pagination"""
         if not self.user.is_authenticated:
             raise PermissionDenied()
 
-        chart_data = []
-        gantt_pid = 1  # Counter for object ID in Gantt chart
-
-        resources = Resource.objects.all()
-
-        # Get all TaskResourceAssigment and group by resources
-        for resource in resources:
-            # Get all TaskResourceAssigment for each resource
-            task_ids = TaskResourceAssigment.objects.filter(
-                resources=resource
-            ).values_list("task_id", flat=True)
-
-            resource_pid = gantt_pid
-
-            chart_data.append(
-                {
-                    "pID": resource_pid,
-                    "pName": resource.name,
+        # Get all jobs with their tasks
+        jobs = Job.objects.prefetch_related("tasks").order_by("priority")
+        
+        # Flatten jobs and tasks into a single list for pagination
+        flattened_data = self.get_flattened_job_data(jobs)
+        
+        # Create paginator
+        paginator = Paginator(flattened_data, page_size)
+        current_page = paginator.get_page(page)
+        
+        # Convert paginated items to gantt format
+        job_data = []
+        for item in current_page:
+            if item["type"] == "job":
+                job_data.append({
+                    "pID": item["pid"],
+                    "pName": item["job"].name,
                     "pStart": "",
                     "pEnd": "",
                     "pClass": "gtaskblue",
@@ -141,83 +80,202 @@ class ResourceGanttChartService:
                     "pDepend": "",
                     "pCaption": "",
                     "pNotes": "",
-                }
-            )
+                    "pPlanStart": item["job"].planned_start_datetime,
+                    "pPlanEnd": item["job"].planned_end_datetime,
+                })
+            else:  # task
+                task = item["task"]
+                resource_name = ""
+                if hasattr(task, "taskresourceassigment"):
+                    assignment = task.taskresourceassigment
+                    if assignment.resources:
+                        resource_name = ", ".join([
+                            resource.name
+                            for resource in assignment.resources.all()
+                        ])
 
-            gantt_pid += 1
+                job_data.append({
+                    "pID": item["pid"],
+                    "pName": task.name,
+                    "pStart": "",
+                    "pEnd": "",
+                    "pClass": "gtaskblue",
+                    "pLink": "",
+                    "pMile": 0,
+                    "pRes": resource_name,
+                    "pComp": 0,
+                    "pGroup": 0,
+                    "pParent": item["parent_pid"],
+                    "pOpen": 1,
+                    "pDepend": list(task.predecessors.values_list("id", flat=True)),
+                    "pNotes": task.notes,
+                    "priority": item["job"].priority,
+                    "pCaption": "",
+                    "pPlanStart": task.planned_start_datetime,
+                    "pPlanEnd": task.planned_end_datetime,
+                })
+
+        return {
+            "data": job_data,
+            "total_count": paginator.count,
+            "page": page,
+            "page_size": page_size,
+            "items_in_page": len(job_data)
+        }
+
+
+# ------------------------------------------------------------------------------
+# Resource Gantt Chart Service
+# ------------------------------------------------------------------------------
+
+
+class ResourceGanttChartService:
+    def __init__(self, user) -> None:
+        self.user = user
+        self.permission_service = AbstractPermissionService(user=user)
+
+    def get_flattened_resource_data(self, resources):
+        """Helper method to flatten resources, jobs and tasks into a single list for pagination"""
+        flattened_data = []
+        pid = 1
+
+        for resource in resources:
+            # Add resource
+            resource_pid = pid
+            flattened_data.append({
+                "type": "resource",
+                "pid": resource_pid,
+                "resource": resource,
+            })
+            pid += 1
+
+            # Get all tasks for this resource
+            task_ids = TaskResourceAssigment.objects.filter(
+                resources=resource
+            ).values_list("task_id", flat=True)
+
             resource_jobs = Job.objects.none()
-
             if task_ids:
-                for task_id in (
-                    task_ids
-                ):  # Get all jobs for each resource based on the assigned tasks
+                for task_id in task_ids:
                     resource_jobs = resource_jobs | Job.objects.filter(
                         tasks__id__contains=task_id
                     )
 
+            # Add jobs and their tasks
             for job in resource_jobs.distinct():
-                job_pid = gantt_pid
-                chart_data.append(
-                    {
-                        "pID": job_pid,
-                        "pName": job.name,
-                        "pStart": "",
-                        "pEnd": "",
-                        "pClass": "gtaskblue",
-                        "pLink": "",
-                        "pMile": 0,
-                        "pRes": "",
-                        "pComp": 0,
-                        "pGroup": 1,
-                        "pOpen": 1,
-                        "pParent": resource_pid,
-                        "pDepend": "",
-                        "pCaption": "",
-                        "pNotes": "",
-                        "pPlanStart": job.planned_start_datetime,
-                        "pPlanEnd": job.planned_end_datetime,
-                    }
-                )
+                job_pid = pid
+                flattened_data.append({
+                    "type": "job",
+                    "pid": job_pid,
+                    "job": job,
+                    "parent_pid": resource_pid,
+                })
+                pid += 1
 
-                gantt_pid += 1
-
+                # Add tasks
                 for task in job.tasks.filter(id__in=task_ids):
-                    if hasattr(task, "taskresourceassigment"):
-                        assignment = task.taskresourceassigment
-                        if assignment.resources:
-                            resource_name = ", ".join(
-                                [
-                                    resource.name
-                                    for resource in assignment.resources.all()
-                                ]
-                            )
-                    else:
-                        resource_name = ""
+                    flattened_data.append({
+                        "type": "task",
+                        "pid": pid,
+                        "task": task,
+                        "parent_pid": job_pid,
+                        "job": job,
+                    })
+                    pid += 1
 
-                    chart_data.append(
-                        {
-                            "pID": gantt_pid,
-                            "pName": task.name,
-                            "pStart": "",
-                            "pEnd": "",
-                            "pClass": "gtaskblue",
-                            "pLink": "",
-                            "pMile": 0,
-                            "pRes": resource_name,
-                            "pComp": 0,
-                            "pGroup": 0,
-                            "pParent": job_pid,
-                            "pOpen": 1,
-                            "pDepend": list(
-                                task.predecessors.values_list("id", flat=True)
-                            ),
-                            "pCaption": "",
-                            "pNotes": "",
-                            "pPlanStart": task.planned_start_datetime,
-                            "pPlanEnd": task.planned_end_datetime,
-                        }
-                    )
+        return flattened_data
 
-                    gantt_pid += 1
+    def map_resources_to_gantt(self, page=1, page_size=50) -> dict:
+        """Map resources to gantt chart data with proper pagination"""
+        if not self.user.is_authenticated:
+            raise PermissionDenied()
 
-        return chart_data
+        # Get all resources
+        resources = Resource.objects.all()
+        
+        # Flatten resources, jobs and tasks into a single list for pagination
+        flattened_data = self.get_flattened_resource_data(resources)
+        
+        # Create paginator
+        paginator = Paginator(flattened_data, page_size)
+        current_page = paginator.get_page(page)
+        
+        # Convert paginated items to gantt format
+        chart_data = []
+        for item in current_page:
+            if item["type"] == "resource":
+                chart_data.append({
+                    "pID": item["pid"],
+                    "pName": item["resource"].name,
+                    "pStart": "",
+                    "pEnd": "",
+                    "pClass": "gtaskblue",
+                    "pLink": "",
+                    "pMile": 0,
+                    "pRes": "",
+                    "pComp": 0,
+                    "pGroup": 1,
+                    "pParent": 0,
+                    "pOpen": 1,
+                    "pDepend": "",
+                    "pCaption": "",
+                    "pNotes": "",
+                })
+            elif item["type"] == "job":
+                chart_data.append({
+                    "pID": item["pid"],
+                    "pName": item["job"].name,
+                    "pStart": "",
+                    "pEnd": "",
+                    "pClass": "gtaskblue",
+                    "pLink": "",
+                    "pMile": 0,
+                    "pRes": "",
+                    "pComp": 0,
+                    "pGroup": 1,
+                    "pOpen": 1,
+                    "pParent": item["parent_pid"],
+                    "pDepend": "",
+                    "pCaption": "",
+                    "pNotes": "",
+                    "pPlanStart": item["job"].planned_start_datetime,
+                    "pPlanEnd": item["job"].planned_end_datetime,
+                })
+            else:  # task
+                task = item["task"]
+                resource_name = ""
+                if hasattr(task, "taskresourceassigment"):
+                    assignment = task.taskresourceassigment
+                    if assignment.resources:
+                        resource_name = ", ".join([
+                            resource.name
+                            for resource in assignment.resources.all()
+                        ])
+
+                chart_data.append({
+                    "pID": item["pid"],
+                    "pName": task.name,
+                    "pStart": "",
+                    "pEnd": "",
+                    "pClass": "gtaskblue",
+                    "pLink": "",
+                    "pMile": 0,
+                    "pRes": resource_name,
+                    "pComp": 0,
+                    "pGroup": 0,
+                    "pParent": item["parent_pid"],
+                    "pOpen": 1,
+                    "pDepend": list(task.predecessors.values_list("id", flat=True)),
+                    "pCaption": "",
+                    "pNotes": "",
+                    "pPlanStart": task.planned_start_datetime,
+                    "pPlanEnd": task.planned_end_datetime,
+                })
+
+        return {
+            "data": chart_data,
+            "total_count": paginator.count,
+            "page": page,
+            "page_size": page_size,
+            "items_in_page": len(chart_data)
+        }

--- a/src/templates/dashboard/job_task_gantt.html
+++ b/src/templates/dashboard/job_task_gantt.html
@@ -1,12 +1,24 @@
 <div class="gantt bg-white p-6 rounded-lg shadow-xl">
-    <h1 class="text-2xl pb-4 font-semibold text-[#181C32]">Job-Task Gantt Chart</h1>
-    <!-- Loading Spinner - Moved outside scrollable container -->
+    <div class="flex justify-between items-center pb-4">
+        <h1 class="text-2xl font-semibold text-[#181C32]">Job-Task Gantt Chart</h1>
+        <div class="text-sm text-gray-600" id="loadingStats">
+            Loaded 0 of 0 items
+        </div>
+    </div>
+    
+    <!-- Initial Loading Spinner -->
     <div id="ganttLoadingForJob" class="relative inset-0 flex items-center justify-center bg-white bg-opacity-80 z-10">
         <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-[#023E8A]"></div>
     </div>
+
     <div style="position:relative; max-height: calc(75vh - 4rem); overflow-y: auto;" id="GanttChartDIV">
         <div id="GanttChartForJob" style="position: relative;">
             <div id="ganttContent"></div>
+        </div>
+        <!-- Bottom Loading Indicator -->
+        <div id="bottomLoader" class="hidden sticky bottom-0 w-full py-2 bg-white bg-opacity-90 flex justify-center items-center gap-2 border-t border-gray-200">
+            <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-[#023E8A]"></div>
+            <span class="text-sm text-gray-600">Loading more items...</span>
         </div>
     </div>
 </div>
@@ -16,18 +28,29 @@
     let allTasks = [];
     let ganttInstance = null;
     let isLoading = false;
-    const ROW_HEIGHT = 40; // Approximate height of each task row
-    const BUFFER_SIZE = 40; // Number of items to render above and below viewport
-    const VIEWPORT_ITEMS = 40; // Approximate number of items visible in viewport
+    let isBackgroundLoading = false;
+    let currentPage = 1;
+    let totalCount = 0;
+    let pageSize = 200;
+    let loadedItemsCount = 0;
+    const ROW_HEIGHT = 40;
+    const BUFFER_SIZE = 40;
+    const VIEWPORT_ITEMS = 40;
     let currentStartIndex = 0;
     let lastScrollTop = 0;
 
     // Hide loading initially since the div starts empty
     document.getElementById('ganttLoadingForJob').style.display = 'none';
+    document.getElementById('bottomLoader').classList.add('hidden');
     
+    function updateLoadingStats() {
+        const statsElement = document.getElementById('loadingStats');
+        const loadingText = isBackgroundLoading ? ' (Loading more...)' : '';
+        statsElement.textContent = `Loaded ${loadedItemsCount} of ${totalCount} items${loadingText}`;
+    }
+
     function initializeJobGantt() {
         var g = new JSGantt.GanttChart(document.getElementById('ganttContent'), 'day');
-        ganttInstance = g;
 
         g.setOptions({
             vCaptionType: 'Complete',
@@ -68,16 +91,26 @@
     }
 
     function drawJobGanttChart(tasks) {
-        if (isLoading) return;
+        if (isLoading || !tasks || tasks.length === 0) return;
         isLoading = true;
 
         try {
+            // Check if the content is already rendered with the same tasks
+            const currentContent = document.getElementById('ganttContent');
+            const currentTasks = currentContent.getAttribute('data-tasks');
+            const newTasksString = JSON.stringify(tasks.map(t => t.pID));
+            
+            // If the same tasks are already rendered, skip redrawing
+            if (currentTasks === newTasksString) {
+                return;
+            }
+
             // Clear and reinitialize
             document.getElementById('ganttContent').innerHTML = '';
             ganttInstance = initializeJobGantt();
 
             // Set container height for proper scrolling
-            const totalHeight = allTasks.length * ROW_HEIGHT;
+            const totalHeight = totalCount * ROW_HEIGHT;
             document.getElementById('GanttChartForJob').style.height = `${totalHeight}px`;
             document.getElementById('ganttContent').style.position = 'absolute';
             document.getElementById('ganttContent').style.width = '100%';
@@ -89,8 +122,84 @@
             });
 
             ganttInstance.Draw();
+            
+            // Store the current tasks for future comparison
+            currentContent.setAttribute('data-tasks', newTasksString);
+            
+            // Force a redraw to ensure proper rendering
+            window.dispatchEvent(new Event('resize'));
         } finally {
             isLoading = false;
+        }
+    }
+
+    async function loadData() {
+        try {
+            isLoading = true;
+            document.getElementById('ganttLoadingForJob').style.display = 'flex';
+            
+            // Load first page
+            const firstPageResponse = await axios.get(
+                `${localStorage.getItem('API_BASE_URL')}api/job/gantt?page=1&page_size=${pageSize}`
+            );
+            
+            const { data, total_count, items_in_page } = firstPageResponse.data;
+            
+            // Set initial data
+            allTasks = data;
+            totalCount = total_count;
+            loadedItemsCount = items_in_page;
+            currentPage = 2; // Set for next page load
+            
+            // Update stats and render first page
+            updateLoadingStats();
+            const { startIndex, endIndex } = getVisibleRange(0);
+            const visibleTasks = allTasks.slice(startIndex, endIndex);
+            drawJobGanttChart(visibleTasks);
+            ensureProperInitialization();
+            
+            // Start background loading if there's more data
+            if (loadedItemsCount < totalCount) {
+                loadRemainingPages();
+            }
+        } catch (error) {
+            console.error('Error loading initial data:', error);
+        } finally {
+            isLoading = false;
+            document.getElementById('ganttLoadingForJob').style.display = 'none';
+        }
+    }
+
+    async function loadRemainingPages() {
+        if (isBackgroundLoading || loadedItemsCount >= totalCount) return;
+        
+        isBackgroundLoading = true;
+        updateLoadingStats();
+        
+        try {
+            while (loadedItemsCount < totalCount) {
+                const response = await axios.get(
+                    `${localStorage.getItem('API_BASE_URL')}api/job/gantt?page=${currentPage}&page_size=${pageSize}`
+                );
+                
+                const { data, items_in_page } = response.data;
+                
+                // Append new data
+                allTasks = [...allTasks, ...data];
+                loadedItemsCount += items_in_page;
+                currentPage++;
+                
+                // Update loading stats
+                updateLoadingStats();
+                
+                // Small delay to prevent UI blocking
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }
+        } catch (error) {
+            console.error('Error loading remaining pages:', error);
+        } finally {
+            isBackgroundLoading = false;
+            updateLoadingStats();
         }
     }
 
@@ -109,51 +218,15 @@
         
         // Only redraw if the visible range has changed significantly
         if (Math.abs(startIndex - currentStartIndex) >= Math.floor(BUFFER_SIZE / 2)) {
-            currentStartIndex = startIndex;
-            const visibleTasks = allTasks.slice(startIndex, endIndex);
-            drawJobGanttChart(visibleTasks);
+            const newStartIndex = Math.floor(startIndex / BUFFER_SIZE) * BUFFER_SIZE;
+            if (newStartIndex !== currentStartIndex) {
+                currentStartIndex = newStartIndex;
+                const visibleTasks = allTasks.slice(startIndex, endIndex);
+                drawJobGanttChart(visibleTasks);
+            }
         }
 
         lastScrollTop = scrollTop;
-    }
-
-    function loadJobGanttData() {
-        document.getElementById('ganttLoadingForJob').style.display = 'flex';
-        isLoading = true;
-        currentStartIndex = 0;
-        lastScrollTop = 0;
-
-        // Check if we have cached data in sessionStorage
-        const cachedData = sessionStorage.getItem('jobGanttData');
-        if (cachedData) {
-            allTasks = JSON.parse(cachedData);
-            const { startIndex, endIndex } = getVisibleRange(0);
-            const initialTasks = allTasks.slice(startIndex, endIndex);
-            drawJobGanttChart(initialTasks);
-            ensureProperInitialization();
-            isLoading = false;
-            document.getElementById('ganttLoadingForJob').style.display = 'none';
-            return;
-        }
-
-        // If no cached data, fetch from API
-        axios.get(`${localStorage.getItem('API_BASE_URL')}api/job/gantt`)
-            .then(response => {
-                allTasks = response.data;
-                // Cache the data in sessionStorage
-                sessionStorage.setItem('jobGanttData', JSON.stringify(allTasks));
-                const { startIndex, endIndex } = getVisibleRange(0);
-                const initialTasks = allTasks.slice(startIndex, endIndex);
-                drawJobGanttChart(initialTasks);
-                ensureProperInitialization();
-            })
-            .catch(error => {
-                console.error(error);
-            })
-            .finally(() => {
-                isLoading = false;
-                document.getElementById('ganttLoadingForJob').style.display = 'none';
-            });
     }
 
     // Function to ensure proper initialization of Gantt chart dimensions
@@ -164,7 +237,7 @@
         
         // Set initial dimensions
         if (allTasks.length > 0) {
-            const totalHeight = allTasks.length * ROW_HEIGHT;
+            const totalHeight = totalCount * ROW_HEIGHT;
             document.getElementById('GanttChartForJob').style.height = `${totalHeight}px`;
             content.style.position = 'relative';
             content.style.width = '100%';
@@ -175,26 +248,42 @@
         }
     }
 
-    // Initial load
-    loadJobGanttData();
+    // Initialize gantt and start loading data
+    ganttInstance = initializeJobGantt();
+    loadData();
 
     // Add scroll event listener with throttle for smoother performance
     document.getElementById('GanttChartDIV').addEventListener('scroll', _.throttle(handleGanttScroll, 100));
 
     // Listen for refresh events
     document.getElementById('jobGanttChart').addEventListener('refreshJobGantt', () => {
-        // Clear session storage to force fresh data load
-        sessionStorage.removeItem('jobGanttData');
-        loadJobGanttData();
+        // Reset all state
+        allTasks = [];
+        currentPage = 1;
+        currentStartIndex = 0;
+        lastScrollTop = 0;
+        loadedItemsCount = 0;
+        totalCount = 0;
+        
+        // Reinitialize and reload
+        ganttInstance = initializeJobGantt();
+        loadData();
     });
 
-    // Handle window resize
-    window.addEventListener('resize', _.debounce(() => {
-        if (!isLoading && allTasks.length > 0) {
-            const container = document.getElementById('GanttChartDIV');
-            const { startIndex, endIndex } = getVisibleRange(container.scrollTop);
-            const visibleTasks = allTasks.slice(startIndex, endIndex);
-            drawJobGanttChart(visibleTasks);
+    // Handle window resize with better debounce and check
+    let resizeTimeout;
+    window.addEventListener('resize', () => {
+        if (resizeTimeout) {
+            clearTimeout(resizeTimeout);
         }
-    }, 100));
+        
+        resizeTimeout = setTimeout(() => {
+            if (!isLoading && allTasks.length > 0) {
+                const container = document.getElementById('GanttChartDIV');
+                const { startIndex, endIndex } = getVisibleRange(container.scrollTop);
+                const visibleTasks = allTasks.slice(startIndex, endIndex);
+                drawJobGanttChart(visibleTasks);
+            }
+        }, 250);  // Increased debounce time
+    });
 </script>

--- a/src/templates/dashboard/resource_gantt.html
+++ b/src/templates/dashboard/resource_gantt.html
@@ -1,9 +1,16 @@
 <div class="gantt bg-white p-6 rounded-lg shadow-xl">
-    <h1 class="text-2xl pb-4 font-semibold text-[#181C32]">Resource Gantt Chart</h1>
-    <!-- Loading Spinner - Moved outside scrollable container -->
+    <div class="flex justify-between items-center pb-4">
+        <h1 class="text-2xl font-semibold text-[#181C32]">Resource Gantt Chart</h1>
+        <div class="text-sm text-gray-600" id="resourceLoadingStats">
+            Loaded 0 of 0 items
+        </div>
+    </div>
+    
+    <!-- Initial Loading Spinner -->
     <div id="ganttLoadingForResource" class="relative inset-0 flex items-center justify-center bg-white bg-opacity-80 z-10">
         <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-[#023E8A]"></div>
     </div>
+
     <div style="position:relative; max-height: calc(75vh - 4rem); overflow-y: auto;" id="ResourceGanttChartDIV">
         <div id="GanttChartForResource" style="position: relative;">
             <div id="resourceGanttContent"></div>
@@ -16,18 +23,28 @@
     let allResourceTasks = [];
     let resourceGanttInstance = null;
     let isResourceLoading = false;
-    const RESOURCE_ROW_HEIGHT = 40; // Approximate height of each task row
-    const RESOURCE_BUFFER_SIZE = 40; // Number of items to render above and below viewport
-    const RESOURCE_VIEWPORT_ITEMS = 40; // Approximate number of items visible in viewport
+    let isResourceBackgroundLoading = false;
+    let currentResourcePage = 1;
+    let totalResourceCount = 0;
+    let resourcePageSize = 200;
+    let loadedResourceCount = 0;
+    const RESOURCE_ROW_HEIGHT = 40;
+    const RESOURCE_BUFFER_SIZE = 40;
+    const RESOURCE_VIEWPORT_ITEMS = 40;
     let currentResourceStartIndex = 0;
     let lastResourceScrollTop = 0;
 
     // Hide loading initially since the div starts empty
     document.getElementById('ganttLoadingForResource').style.display = 'none';
+    
+    function updateResourceLoadingStats() {
+        const statsElement = document.getElementById('resourceLoadingStats');
+        const loadingText = isResourceBackgroundLoading ? ' (Loading more...)' : '';
+        statsElement.textContent = `Loaded ${loadedResourceCount} of ${totalResourceCount} items${loadingText}`;
+    }
 
     function initializeResourceGantt() {
         var g = new JSGantt.GanttChart(document.getElementById('resourceGanttContent'), 'day');
-        resourceGanttInstance = g;
 
         g.setOptions({
             vCaptionType: 'Complete',
@@ -63,16 +80,26 @@
     }
 
     function drawResourceGanttChart(tasks) {
-        if (isResourceLoading) return;
+        if (isResourceLoading || !tasks || tasks.length === 0) return;
         isResourceLoading = true;
 
         try {
+            // Check if the content is already rendered with the same tasks
+            const currentContent = document.getElementById('resourceGanttContent');
+            const currentTasks = currentContent.getAttribute('data-tasks');
+            const newTasksString = JSON.stringify(tasks.map(t => t.pID));
+            
+            // If the same tasks are already rendered, skip redrawing
+            if (currentTasks === newTasksString) {
+                return;
+            }
+
             // Clear and reinitialize
             document.getElementById('resourceGanttContent').innerHTML = '';
             resourceGanttInstance = initializeResourceGantt();
 
             // Set container height for proper scrolling
-            const totalHeight = allResourceTasks.length * RESOURCE_ROW_HEIGHT;
+            const totalHeight = totalResourceCount * RESOURCE_ROW_HEIGHT;
             document.getElementById('GanttChartForResource').style.height = `${totalHeight}px`;
             document.getElementById('resourceGanttContent').style.position = 'absolute';
             document.getElementById('resourceGanttContent').style.width = '100%';
@@ -84,8 +111,84 @@
             });
 
             resourceGanttInstance.Draw();
+            
+            // Store the current tasks for future comparison
+            currentContent.setAttribute('data-tasks', newTasksString);
+            
+            // Force a redraw to ensure proper rendering
+            window.dispatchEvent(new Event('resize'));
         } finally {
             isResourceLoading = false;
+        }
+    }
+
+    async function loadResourceData() {
+        try {
+            isResourceLoading = true;
+            document.getElementById('ganttLoadingForResource').style.display = 'flex';
+            
+            // Load first page
+            const firstPageResponse = await axios.get(
+                `${localStorage.getItem('API_BASE_URL')}api/resource/gantt?page=1&page_size=${resourcePageSize}`
+            );
+            
+            const { data, total_count, items_in_page } = firstPageResponse.data;
+            
+            // Set initial data
+            allResourceTasks = data;
+            totalResourceCount = total_count;
+            loadedResourceCount = items_in_page;
+            currentResourcePage = 2; // Set for next page load
+            
+            // Update stats and render first page
+            updateResourceLoadingStats();
+            const { startIndex, endIndex } = getVisibleResourceRange(0);
+            const visibleTasks = allResourceTasks.slice(startIndex, endIndex);
+            drawResourceGanttChart(visibleTasks);
+            ensureProperResourceInitialization();
+            
+            // Start background loading if there's more data
+            if (loadedResourceCount < totalResourceCount) {
+                loadRemainingResourcePages();
+            }
+        } catch (error) {
+            console.error('Error loading initial resource data:', error);
+        } finally {
+            isResourceLoading = false;
+            document.getElementById('ganttLoadingForResource').style.display = 'none';
+        }
+    }
+
+    async function loadRemainingResourcePages() {
+        if (isResourceBackgroundLoading || loadedResourceCount >= totalResourceCount) return;
+        
+        isResourceBackgroundLoading = true;
+        updateResourceLoadingStats();
+        
+        try {
+            while (loadedResourceCount < totalResourceCount) {
+                const response = await axios.get(
+                    `${localStorage.getItem('API_BASE_URL')}api/resource/gantt?page=${currentResourcePage}&page_size=${resourcePageSize}`
+                );
+                
+                const { data, items_in_page } = response.data;
+                
+                // Append new data
+                allResourceTasks = [...allResourceTasks, ...data];
+                loadedResourceCount += items_in_page;
+                currentResourcePage++;
+                
+                // Update loading stats
+                updateResourceLoadingStats();
+                
+                // Small delay to prevent UI blocking
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }
+        } catch (error) {
+            console.error('Error loading remaining resource pages:', error);
+        } finally {
+            isResourceBackgroundLoading = false;
+            updateResourceLoadingStats();
         }
     }
 
@@ -104,51 +207,15 @@
         
         // Only redraw if the visible range has changed significantly
         if (Math.abs(startIndex - currentResourceStartIndex) >= Math.floor(RESOURCE_BUFFER_SIZE / 2)) {
-            currentResourceStartIndex = startIndex;
-            const visibleTasks = allResourceTasks.slice(startIndex, endIndex);
-            drawResourceGanttChart(visibleTasks);
+            const newStartIndex = Math.floor(startIndex / RESOURCE_BUFFER_SIZE) * RESOURCE_BUFFER_SIZE;
+            if (newStartIndex !== currentResourceStartIndex) {
+                currentResourceStartIndex = newStartIndex;
+                const visibleTasks = allResourceTasks.slice(startIndex, endIndex);
+                drawResourceGanttChart(visibleTasks);
+            }
         }
 
         lastResourceScrollTop = scrollTop;
-    }
-
-    function loadResourceGanttData() {
-        document.getElementById('ganttLoadingForResource').style.display = 'flex';
-        isResourceLoading = true;
-        currentResourceStartIndex = 0;
-        lastResourceScrollTop = 0;
-
-        // Check if we have cached data in sessionStorage
-        const cachedData = sessionStorage.getItem('resourceGanttData');
-        if (cachedData) {
-            allResourceTasks = JSON.parse(cachedData);
-            const { startIndex, endIndex } = getVisibleResourceRange(0);
-            const initialTasks = allResourceTasks.slice(startIndex, endIndex);
-            drawResourceGanttChart(initialTasks);
-            ensureProperResourceInitialization();
-            isResourceLoading = false;
-            document.getElementById('ganttLoadingForResource').style.display = 'none';
-            return;
-        }
-
-        // If no cached data, fetch from API
-        axios.get(`${localStorage.getItem('API_BASE_URL')}api/resource/gantt`)
-            .then(response => {
-                allResourceTasks = response.data;
-                // Cache the data in sessionStorage
-                sessionStorage.setItem('resourceGanttData', JSON.stringify(allResourceTasks));
-                const { startIndex, endIndex } = getVisibleResourceRange(0);
-                const initialTasks = allResourceTasks.slice(startIndex, endIndex);
-                drawResourceGanttChart(initialTasks);
-                ensureProperResourceInitialization();
-            })
-            .catch(error => {
-                console.error(error);
-            })
-            .finally(() => {
-                isResourceLoading = false;
-                document.getElementById('ganttLoadingForResource').style.display = 'none';
-            });
     }
 
     // Function to ensure proper initialization of Resource Gantt chart dimensions
@@ -159,7 +226,7 @@
         
         // Set initial dimensions
         if (allResourceTasks.length > 0) {
-            const totalHeight = allResourceTasks.length * RESOURCE_ROW_HEIGHT;
+            const totalHeight = totalResourceCount * RESOURCE_ROW_HEIGHT;
             document.getElementById('GanttChartForResource').style.height = `${totalHeight}px`;
             content.style.position = 'relative';
             content.style.width = '100%';
@@ -170,26 +237,42 @@
         }
     }
 
-    // Initial load
-    loadResourceGanttData();
+    // Initialize gantt and start loading data
+    resourceGanttInstance = initializeResourceGantt();
+    loadResourceData();
 
     // Add scroll event listener with throttle for smoother performance
     document.getElementById('ResourceGanttChartDIV').addEventListener('scroll', _.throttle(handleResourceGanttScroll, 100));
 
     // Listen for refresh events
     document.getElementById('resourceGanttChart').addEventListener('refreshResourceGantt', () => {
-        // Clear session storage to force fresh data load
-        sessionStorage.removeItem('resourceGanttData');
-        loadResourceGanttData();
+        // Reset all state
+        allResourceTasks = [];
+        currentResourcePage = 1;
+        currentResourceStartIndex = 0;
+        lastResourceScrollTop = 0;
+        loadedResourceCount = 0;
+        totalResourceCount = 0;
+        
+        // Reinitialize and reload
+        resourceGanttInstance = initializeResourceGantt();
+        loadResourceData();
     });
 
-    // Handle window resize
-    window.addEventListener('resize', _.debounce(() => {
-        if (!isResourceLoading && allResourceTasks.length > 0) {
-            const container = document.getElementById('ResourceGanttChartDIV');
-            const { startIndex, endIndex } = getVisibleResourceRange(container.scrollTop);
-            const visibleTasks = allResourceTasks.slice(startIndex, endIndex);
-            drawResourceGanttChart(visibleTasks);
+    // Handle window resize with better debounce and check
+    let resourceResizeTimeout;
+    window.addEventListener('resize', () => {
+        if (resourceResizeTimeout) {
+            clearTimeout(resourceResizeTimeout);
         }
-    }, 100));
+        
+        resourceResizeTimeout = setTimeout(() => {
+            if (!isResourceLoading && allResourceTasks.length > 0) {
+                const container = document.getElementById('ResourceGanttChartDIV');
+                const { startIndex, endIndex } = getVisibleResourceRange(container.scrollTop);
+                const visibleTasks = allResourceTasks.slice(startIndex, endIndex);
+                drawResourceGanttChart(visibleTasks);
+            }
+        }, 250);  // Increased debounce time
+    });
 </script>


### PR DESCRIPTION
Fixes #270.

This PR, adds the pagination like architecture for fetching the data in `gantt chart` so that we can avoid fetching the large data all at once. With this approach, we are currently fetching 200 datapoint per page making it much faster and smoother experience.


TODO:
- [x] testing current implementation for every edge cases
- [x] finding any better approach
